### PR TITLE
T head calculation correction

### DIFF
--- a/ahead_co_po_go.py
+++ b/ahead_co_po_go.py
@@ -171,7 +171,7 @@ class HGT(torch.nn.Module):
             for i in range(T_head[node_type].shape[0]):
                 T_head[node_type][i, 0] = weight_type[0] * t_head[node_type][i, 0]
                 T_head[node_type][i, 1] = weight_type[1] * t_head[node_type][i, 1]
-            T_head[node_type] = F.softmax(T_head[node_type], dim=0)
+            T_head[node_type] = F.softmax(T_head[node_type], dim=1)
         for edge_type in edge_index_dict.keys():
             A_head[edge_type] = torch.sigmoid(torch.mm(Z_dict[edge_type[0]], Z_dict[edge_type[2]].T))
 

--- a/ahead_imdb.py
+++ b/ahead_imdb.py
@@ -166,7 +166,7 @@ class HGT(torch.nn.Module):
             for i in range(T_head[node_type].shape[0]):
                 T_head[node_type][i, 0] = weight_type[0] * t_head[node_type][i, 0]
                 T_head[node_type][i, 1] = weight_type[1] * t_head[node_type][i, 1]
-            T_head[node_type] = F.softmax(T_head[node_type], dim=0)
+            T_head[node_type] = F.softmax(T_head[node_type], dim=1)
         for edge_type in edge_index_dict.keys():
             A_head[edge_type] = torch.sigmoid(torch.mm(Z_dict[edge_type[0]], Z_dict[edge_type[2]].T))
 


### PR DESCRIPTION
I was struggling with your code trying to use it for my graphs (supply chain) and ran across sth I recognized as a problem with the calculation of T_head. The softmax used for the T_head calculation was by mistake computed along columns (dim=0 in the invocation of F.Softmax) instead of rows (dim=1). Please, find the suggested tiny correction. Besides, I would like to congratulate the great paper - it was a real pleasure to read it and use the ideas and code. I will definitely cite it, as I am on the way to writing the paper on the application of AHEAD in the detection of anomalies in supply chain representing graphs.